### PR TITLE
Allow subcommands without extra args in BirdArgparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ UI. They may change without warning.
 Current utilities:
 
 * `SeqReader().readf[aq]` - pure python generator function for reading FASTA / FASTQ files
-* `BirdArgparser` - opinionated way of presenting help messages - default help prints examples with colour, `--full-help` shows a man page. `--full-help-roff` can be used to generate HTML versions. Logging arguments are batteries included.
+* `BirdArgparser` - opinionated way of presenting help messages - default help prints examples with colour, `--full-help` shows a man page. `--full-help-roff` can be used to generate HTML versions. Logging arguments are batteries included. Subcommands that should run without additional arguments can be created with `allow_no_args=True`.
 * `table_roff` for generating ROFF format tables for use with `BirdArgparser`
 * `in_working_directory` and `in_tempdir` are context functions for temporary switching to a directory
 * `iterable_chunks` provides chunking for iterables

--- a/bird_tool_utils/argparsing.py
+++ b/bird_tool_utils/argparsing.py
@@ -94,8 +94,10 @@ class BirdArgparser:
         self._subparser_name_to_parser = {}
         self._subparser_name_to_description = {}
         self._groups_of_subparsers = OrderedDict()
+        self._subparsers_allow_no_args = set()
 
-    def new_subparser(self, parser_name, parser_description, parser_group=None):
+    def new_subparser(self, parser_name, parser_description, parser_group=None,
+                      allow_no_args=False):
         '''Create a new subparser, and return it. Keep track of all subparsers
         so that they can be referred to with --full-help.
 
@@ -105,6 +107,8 @@ class BirdArgparser:
 
         Optional:
         * parser_group: str or None. Define grouping of subcommands [default: None]
+        * allow_no_args: allow subcommand execution with no further
+          arguments, rather than printing help [default: False]
         '''
         if len(self._subparser_name_to_parser) == 0:
             self._subparsers = self._child_parser.add_subparsers(
@@ -120,6 +124,8 @@ class BirdArgparser:
             if parser_group not in self._groups_of_subparsers:
                 self._groups_of_subparsers[parser_group] = []
             self._groups_of_subparsers[parser_group].append(parser_name)
+        if allow_no_args:
+            self._subparsers_allow_no_args.add(parser_name)
         return subpar
 
     def _add_boring_common_arguments(self, parser=None):
@@ -172,7 +178,8 @@ class BirdArgparser:
             # Determine whether help was specified before argument parsing.
             print_help = True
             if sys.argv[1] in self._subparser_name_to_parser:
-                if '-h' in sys.argv or '--help' in sys.argv or len(sys.argv) == 2:
+                if '-h' in sys.argv or '--help' in sys.argv or \
+                   (len(sys.argv) == 2 and sys.argv[1] not in self._subparsers_allow_no_args):
                     self._print_short_help(sys.argv[1])
                     sys.exit(0)
                 elif '--%s' % BirdArgparser.FULL_HELP_FLAG in sys.argv or \

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,18 @@
+import sys
+import types
+
+build_manpages = types.ModuleType("build_manpages")
+manpage = types.ModuleType("manpage")
+
+class Manpage:  # minimal stub used in tests
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __str__(self):
+        return ""
+
+manpage.Manpage = Manpage
+build_manpages.manpage = manpage
+
+sys.modules.setdefault("build_manpages", build_manpages)
+sys.modules.setdefault("build_manpages.manpage", manpage)

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -37,6 +37,28 @@ class Tests(unittest.TestCase):
     def test_str2bool(self):
         self.assertEqual(True, str2bool('y'))
         self.assertEqual(False, str2bool('false'))
+
+    def test_allow_no_args_subparser(self):
+        saved = sys.argv
+        parser = BirdArgparser(program='TestProgram', program_invocation='testprog')
+        parser.new_subparser('build', 'desc', allow_no_args=True)
+        sys.argv = ['testprog', 'build']
+        try:
+            args = parser.parse_the_args()
+            self.assertFalse(args.debug)
+        finally:
+            sys.argv = saved
+
+    def test_default_requires_args(self):
+        saved = sys.argv
+        parser = BirdArgparser(program='TestProgram', program_invocation='testprog')
+        parser.new_subparser('build', 'desc')
+        sys.argv = ['testprog', 'build']
+        try:
+            with self.assertRaises(SystemExit):
+                parser.parse_the_args()
+        finally:
+            sys.argv = saved
         
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `allow_no_args` option to BirdArgparser subparsers
- document allow_no_args in README
- test no-arg subparser execution and stub build_manpages for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a29e8e1c70832aa01994a97f10d0fe