### PR TITLE
Hide excluded subparsers from help

### DIFF
--- a/bird_tool_utils/argparsing.py
+++ b/bird_tool_utils/argparsing.py
@@ -107,7 +107,10 @@ class BirdArgparser:
         * parser_description: description of subcommand
 
         Optional:
-        * parser_group: str or None. Define grouping of subcommands [default: None]
+        * parser_group: str or None. Define grouping of subcommands. Use the
+          special value 'exclude' to hide the subcommand from the main help
+          output while still allowing it to be invoked directly
+          [default: None]
         * allow_no_args: allow subcommand execution with no further
           arguments, rather than printing help [default: False]
         '''


### PR DESCRIPTION
## Summary
- support hiding subcommands from main help by marking them with `parser_group='exclude'`
- add regression test for excluded subcommands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba651ad48c832a89d7856d9a71f529